### PR TITLE
フィルムボーダー機能を追加（暗背景＋SVGぼかし縁）

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,13 +97,14 @@
 
       <div class="bottom">
         <div style="display:flex; align-items:center; gap:10px; margin-right:20px;">
-          <label for="borderSlider" style="font-size:14px;">白枠の太さ:</label>
+          <label for="borderSlider" style="font-size:14px;">枠の太さ:</label>
           <input type="range" id="borderSlider" min="0" max="30" value="5" step="1">
           <span id="borderValue" style="font-size:14px; width:30px;">5%</span>
         </div>
+        <button id="borderTypeBtn" type="button" style="background:#555;">枠: 白</button>
         <button id="saveBtn" disabled>クロップ保存</button>
-        <button id="fitBtn" disabled>白枠を追加</button>
-        <button id="batchBtn" disabled>全画像を白枠で保存</button>
+        <button id="fitBtn" disabled>枠を追加</button>
+        <button id="batchBtn" disabled>全画像を枠付きで保存</button>
         <button id="resetBtn" disabled>リセット</button>
       </div>
 

--- a/main.js
+++ b/main.js
@@ -45,50 +45,91 @@ ipcMain.handle("crop-save", async (_, { inputPath, outDir, rect, aspectRatio }) 
   return { ok: true };
 });
 
-ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPercent }) => {
+ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPercent, borderType = "white" }) => {
   const name = path.basename(inputPath, path.extname(inputPath));
-  const outPath = path.join(outDir, `${name}_fitted_${aspectRatio.replace(":", "x")}_${borderPercent}pct.jpg`);
-  
+  const suffix = borderType === "film" ? "film" : "white";
+  const outPath = path.join(outDir, `${name}_fitted_${aspectRatio.replace(":", "x")}_${borderPercent}pct_${suffix}.jpg`);
+
   const img = sharp(inputPath).rotate();
   const meta = await img.metadata();
-  const bg = { r: 255, g: 255, b: 255, alpha: 1 };
-  
   const p = parseFloat(borderPercent) / 100;
-  const scale = 1 - (p * 2);
+  const scale = 1 - p * 2;
 
-  if (aspectRatio === "Original") {
-    const margin = Math.round(Math.max(meta.width, meta.height) * p);
-    await img.extend({
-      top: margin, bottom: margin, left: margin, right: margin,
-      background: bg
-    }).jpeg({ quality: 95 }).toFile(outPath);
-  } else {
-    const ratio = aspectRatio === "1:1" ? 1 : 4 / 3;
-    let canvasW, canvasH;
-    
-    if (meta.width / meta.height > ratio) {
-      canvasW = meta.width;
-      canvasH = Math.round(meta.width / ratio);
+  if (borderType === "white") {
+    const bg = { r: 255, g: 255, b: 255, alpha: 1 };
+    if (aspectRatio === "Original") {
+      const margin = Math.round(Math.max(meta.width, meta.height) * p);
+      await img.extend({ top: margin, bottom: margin, left: margin, right: margin, background: bg })
+        .jpeg({ quality: 95 }).toFile(outPath);
     } else {
-      canvasH = meta.height;
-      canvasW = Math.round(meta.height * ratio);
+      const ratio = aspectRatio === "1:1" ? 1 : 4 / 3;
+      let canvasW, canvasH;
+      if (meta.width / meta.height > ratio) { canvasW = meta.width; canvasH = Math.round(meta.width / ratio); }
+      else { canvasH = meta.height; canvasW = Math.round(meta.height * ratio); }
+      const contentW = Math.max(1, Math.round(canvasW * scale));
+      const contentH = Math.max(1, Math.round(canvasH * scale));
+      await img.resize({ width: contentW, height: contentH, fit: "contain", background: bg })
+        .extend({
+          top: Math.floor((canvasH - contentH) / 2), bottom: Math.ceil((canvasH - contentH) / 2),
+          left: Math.floor((canvasW - contentW) / 2), right: Math.ceil((canvasW - contentW) / 2),
+          background: bg
+        }).jpeg({ quality: 95 }).toFile(outPath);
+    }
+  } else {
+    // Film border: dark background + feathered inner edge via SVG overlay
+    const darkBg = { r: 10, g: 10, b: 10 };
+    let canvasW, canvasH, leftOffset, topOffset, contentW, contentH;
+
+    if (aspectRatio === "Original") {
+      const margin = Math.round(Math.max(meta.width, meta.height) * p);
+      canvasW = meta.width + margin * 2;
+      canvasH = meta.height + margin * 2;
+      contentW = meta.width;
+      contentH = meta.height;
+      leftOffset = margin;
+      topOffset = margin;
+    } else {
+      const ratio = aspectRatio === "1:1" ? 1 : 4 / 3;
+      if (meta.width / meta.height > ratio) { canvasW = meta.width; canvasH = Math.round(meta.width / ratio); }
+      else { canvasH = meta.height; canvasW = Math.round(meta.height * ratio); }
+      contentW = Math.max(1, Math.round(canvasW * scale));
+      contentH = Math.max(1, Math.round(canvasH * scale));
+      leftOffset = Math.floor((canvasW - contentW) / 2);
+      topOffset = Math.floor((canvasH - contentH) / 2);
     }
 
-    const contentW = Math.max(1, Math.round(canvasW * scale));
-    const contentH = Math.max(1, Math.round(canvasH * scale));
+    // Build extended image on dark background
+    let extendedBuf;
+    if (aspectRatio === "Original") {
+      extendedBuf = await sharp(inputPath).rotate()
+        .extend({ top: topOffset, bottom: topOffset, left: leftOffset, right: leftOffset, background: darkBg })
+        .png().toBuffer();
+    } else {
+      extendedBuf = await sharp(inputPath).rotate()
+        .resize({ width: contentW, height: contentH, fit: "contain", background: darkBg })
+        .extend({
+          top: topOffset, bottom: canvasH - contentH - topOffset,
+          left: leftOffset, right: canvasW - contentW - leftOffset,
+          background: darkBg
+        }).png().toBuffer();
+    }
 
-    await img.resize({
-      width: contentW,
-      height: contentH,
-      fit: "contain",
-      background: bg
-    }).extend({
-      top: Math.floor((canvasH - contentH) / 2),
-      bottom: Math.ceil((canvasH - contentH) / 2),
-      left: Math.floor((canvasW - contentW) / 2),
-      right: Math.ceil((canvasW - contentW) / 2),
-      background: bg
-    }).jpeg({ quality: 95 }).toFile(outPath);
+    // SVG overlay: feathered dark frame that bleeds slightly into the image edge
+    const blurSize = Math.max(5, Math.round(Math.min(leftOffset, topOffset) * 0.08));
+    const frameSvg = Buffer.from(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${canvasW}" height="${canvasH}">` +
+      `<defs><filter id="b" x="-30%" y="-30%" width="160%" height="160%">` +
+      `<feGaussianBlur stdDeviation="${blurSize}"/></filter>` +
+      `<mask id="m"><rect width="${canvasW}" height="${canvasH}" fill="white"/>` +
+      `<rect x="${leftOffset}" y="${topOffset}" width="${contentW}" height="${contentH}" fill="black" filter="url(#b)"/>` +
+      `</mask></defs>` +
+      `<rect width="${canvasW}" height="${canvasH}" fill="rgb(10,10,10)" mask="url(#m)"/>` +
+      `</svg>`
+    );
+
+    await sharp(extendedBuf)
+      .composite([{ input: frameSvg, top: 0, left: 0 }])
+      .jpeg({ quality: 95 }).toFile(outPath);
   }
   return { ok: true };
 });

--- a/renderer.js
+++ b/renderer.js
@@ -12,6 +12,7 @@ const resetBtn = document.getElementById("resetBtn");
 const toggleRatioBtn = document.getElementById("toggleRatioBtn");
 const borderSlider = document.getElementById("borderSlider");
 const borderValue = document.getElementById("borderValue");
+const borderTypeBtn = document.getElementById("borderTypeBtn");
 const counter = document.getElementById("counter");
 const stageHost = document.getElementById("stageHost");
 const pathLabel = document.getElementById("pathLabel");
@@ -21,6 +22,7 @@ let idx = -1;
 let outDir = null;
 let aspectRatio = "Original"; // デフォルトを「元の比率」に変更
 let borderPercent = 5;
+let borderType = "white"; // "white" or "film"
 
 let stage, layer, imgNode, bgRect;
 let fit = { x: 0, y: 0, w: 0, h: 0, scale: 1 };
@@ -30,7 +32,6 @@ function initStage() {
   layer = new Konva.Layer();
   stage.add(layer);
   
-  // 白枠のプレビュー用背景
   bgRect = new Konva.Rect({ fill: "white", shadowBlur: 10, shadowOpacity: 0.3 });
   layer.add(bgRect);
   
@@ -42,6 +43,14 @@ initStage();
 borderSlider.oninput = () => {
   borderPercent = parseInt(borderSlider.value);
   borderValue.textContent = `${borderPercent}%`;
+  updateUI();
+  layer.draw();
+};
+
+borderTypeBtn.onclick = () => {
+  borderType = borderType === "white" ? "film" : "white";
+  borderTypeBtn.textContent = borderType === "white" ? "枠: 白" : "枠: フィルム";
+  borderTypeBtn.style.background = borderType === "white" ? "#555" : "#2a1a0a";
   updateUI();
   layer.draw();
 };
@@ -118,7 +127,7 @@ function updateUI() {
     }
   }
 
-  // プレビューの白い四角（白枠）を更新
+  bgRect.fill(borderType === "film" ? "#0a0a0a" : "white");
   bgRect.size({ width: canvasW, height: canvasH }).position({
     x: (stage.width() - canvasW) / 2,
     y: (stage.height() - canvasH) / 2
@@ -157,7 +166,7 @@ toggleRatioBtn.onclick = async () => {
 
 fitBtn.onclick = async () => {
   fitBtn.disabled = true;
-  await ipcRenderer.invoke("fit-save", { inputPath: files[idx], outDir, aspectRatio, borderPercent });
+  await ipcRenderer.invoke("fit-save", { inputPath: files[idx], outDir, aspectRatio, borderPercent, borderType });
   if (idx < files.length - 1) { idx++; await load(idx); }
   else { fitBtn.disabled = false; updateUI(); }
 };
@@ -171,7 +180,7 @@ batchBtn.onclick = async () => {
     batchBtn.textContent = `保存中 (${i + 1}/${files.length})...`;
     idx = i;
     await load(idx); // 読み込み完了を待機
-    await ipcRenderer.invoke("fit-save", { inputPath: files[i], outDir, aspectRatio, borderPercent });
+    await ipcRenderer.invoke("fit-save", { inputPath: files[i], outDir, aspectRatio, borderPercent, borderType });
   }
   
   batchBtn.disabled = false;


### PR DESCRIPTION
枠の種類を白とフィルムで切り替えられるトグルボタンを追加。
フィルム選択時はダーク背景にSVGオーバーレイで内側エッジをわずかにぼかした
フィルムネガ風の枠を生成する。白枠の既存動作は維持。