### PR TITLE
フィルムボーダーのSVGオーバーレイを削除し暗背景のみに簡略化

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,60 +76,26 @@ ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPer
         }).jpeg({ quality: 95 }).toFile(outPath);
     }
   } else {
-    // Film border: dark background + feathered inner edge via SVG overlay
+    // Film border: image on near-black background
     const darkBg = { r: 10, g: 10, b: 10 };
-    let canvasW, canvasH, leftOffset, topOffset, contentW, contentH;
-
     if (aspectRatio === "Original") {
       const margin = Math.round(Math.max(meta.width, meta.height) * p);
-      canvasW = meta.width + margin * 2;
-      canvasH = meta.height + margin * 2;
-      contentW = meta.width;
-      contentH = meta.height;
-      leftOffset = margin;
-      topOffset = margin;
+      await img.extend({ top: margin, bottom: margin, left: margin, right: margin, background: darkBg })
+        .jpeg({ quality: 95 }).toFile(outPath);
     } else {
       const ratio = aspectRatio === "1:1" ? 1 : 4 / 3;
+      let canvasW, canvasH;
       if (meta.width / meta.height > ratio) { canvasW = meta.width; canvasH = Math.round(meta.width / ratio); }
       else { canvasH = meta.height; canvasW = Math.round(meta.height * ratio); }
-      contentW = Math.max(1, Math.round(canvasW * scale));
-      contentH = Math.max(1, Math.round(canvasH * scale));
-      leftOffset = Math.floor((canvasW - contentW) / 2);
-      topOffset = Math.floor((canvasH - contentH) / 2);
-    }
-
-    // Build extended image on dark background
-    let extendedBuf;
-    if (aspectRatio === "Original") {
-      extendedBuf = await sharp(inputPath).rotate()
-        .extend({ top: topOffset, bottom: topOffset, left: leftOffset, right: leftOffset, background: darkBg })
-        .png().toBuffer();
-    } else {
-      extendedBuf = await sharp(inputPath).rotate()
-        .resize({ width: contentW, height: contentH, fit: "contain", background: darkBg })
+      const contentW = Math.max(1, Math.round(canvasW * scale));
+      const contentH = Math.max(1, Math.round(canvasH * scale));
+      await img.resize({ width: contentW, height: contentH, fit: "contain", background: darkBg })
         .extend({
-          top: topOffset, bottom: canvasH - contentH - topOffset,
-          left: leftOffset, right: canvasW - contentW - leftOffset,
+          top: Math.floor((canvasH - contentH) / 2), bottom: Math.ceil((canvasH - contentH) / 2),
+          left: Math.floor((canvasW - contentW) / 2), right: Math.ceil((canvasW - contentW) / 2),
           background: darkBg
-        }).png().toBuffer();
+        }).jpeg({ quality: 95 }).toFile(outPath);
     }
-
-    // SVG overlay: feathered dark frame that bleeds slightly into the image edge
-    const blurSize = Math.max(5, Math.round(Math.min(leftOffset, topOffset) * 0.08));
-    const frameSvg = Buffer.from(
-      `<svg xmlns="http://www.w3.org/2000/svg" width="${canvasW}" height="${canvasH}">` +
-      `<defs><filter id="b" x="-30%" y="-30%" width="160%" height="160%">` +
-      `<feGaussianBlur stdDeviation="${blurSize}"/></filter>` +
-      `<mask id="m"><rect width="${canvasW}" height="${canvasH}" fill="white"/>` +
-      `<rect x="${leftOffset}" y="${topOffset}" width="${contentW}" height="${contentH}" fill="black" filter="url(#b)"/>` +
-      `</mask></defs>` +
-      `<rect width="${canvasW}" height="${canvasH}" fill="rgb(10,10,10)" mask="url(#m)"/>` +
-      `</svg>`
-    );
-
-    await sharp(extendedBuf)
-      .composite([{ input: frameSvg, top: 0, left: 0 }])
-      .jpeg({ quality: 95 }).toFile(outPath);
   }
   return { ok: true };
 });


### PR DESCRIPTION
SVGマスク+ブラーによる羽毛状縁取りが白いアーティファクトを生成していたため
削除。参考画像と同様のシャープなエッジの暗背景（rgb 10,10,10）のみで実装。