### PR TITLE
フィルムボーダーを3層構造に修正（白外枠→暗枠→写真）

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,12 +76,16 @@ ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPer
         }).jpeg({ quality: 95 }).toFile(outPath);
     }
   } else {
-    // Film border: image on near-black background
+    // Film border: photo → dark extend → thin white outer border
     const darkBg = { r: 10, g: 10, b: 10 };
+    const whiteBg = { r: 255, g: 255, b: 255 };
+    const whitePx = Math.max(10, Math.round(Math.max(meta.width, meta.height) * 0.007));
+
+    let darkBuf;
     if (aspectRatio === "Original") {
       const margin = Math.round(Math.max(meta.width, meta.height) * p);
-      await img.extend({ top: margin, bottom: margin, left: margin, right: margin, background: darkBg })
-        .jpeg({ quality: 95 }).toFile(outPath);
+      darkBuf = await img.extend({ top: margin, bottom: margin, left: margin, right: margin, background: darkBg })
+        .png().toBuffer();
     } else {
       const ratio = aspectRatio === "1:1" ? 1 : 4 / 3;
       let canvasW, canvasH;
@@ -89,13 +93,16 @@ ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPer
       else { canvasH = meta.height; canvasW = Math.round(meta.height * ratio); }
       const contentW = Math.max(1, Math.round(canvasW * scale));
       const contentH = Math.max(1, Math.round(canvasH * scale));
-      await img.resize({ width: contentW, height: contentH, fit: "contain", background: darkBg })
+      darkBuf = await img.resize({ width: contentW, height: contentH, fit: "contain", background: darkBg })
         .extend({
           top: Math.floor((canvasH - contentH) / 2), bottom: Math.ceil((canvasH - contentH) / 2),
           left: Math.floor((canvasW - contentW) / 2), right: Math.ceil((canvasW - contentW) / 2),
           background: darkBg
-        }).jpeg({ quality: 95 }).toFile(outPath);
+        }).png().toBuffer();
     }
+    await sharp(darkBuf)
+      .extend({ top: whitePx, bottom: whitePx, left: whitePx, right: whitePx, background: whiteBg })
+      .jpeg({ quality: 95 }).toFile(outPath);
   }
   return { ok: true };
 });

--- a/renderer.js
+++ b/renderer.js
@@ -24,17 +24,20 @@ let aspectRatio = "Original"; // デフォルトを「元の比率」に変更
 let borderPercent = 5;
 let borderType = "white"; // "white" or "film"
 
-let stage, layer, imgNode, bgRect;
+let stage, layer, imgNode, bgRect, filmRect;
 let fit = { x: 0, y: 0, w: 0, h: 0, scale: 1 };
 
 function initStage() {
   stage = new Konva.Stage({ container: "stageHost", width: 1100, height: 640 });
   layer = new Konva.Layer();
   stage.add(layer);
-  
+
   bgRect = new Konva.Rect({ fill: "white", shadowBlur: 10, shadowOpacity: 0.3 });
   layer.add(bgRect);
-  
+
+  filmRect = new Konva.Rect({ fill: "#0a0a0a", visible: false });
+  layer.add(filmRect);
+
   imgNode = new Konva.Image();
   layer.add(imgNode);
 }
@@ -127,11 +130,26 @@ function updateUI() {
     }
   }
 
-  bgRect.fill(borderType === "film" ? "#0a0a0a" : "white");
-  bgRect.size({ width: canvasW, height: canvasH }).position({
-    x: (stage.width() - canvasW) / 2,
-    y: (stage.height() - canvasH) / 2
+  const WHITE_PX = 8; // 白枠の固定厚さ（プレビュー用px）
+  const isFilm = borderType === "film";
+
+  // 白枠（外側）- film時は少し大きめに確保
+  const outerW = isFilm ? canvasW + WHITE_PX * 2 : canvasW;
+  const outerH = isFilm ? canvasH + WHITE_PX * 2 : canvasH;
+  bgRect.fill("white");
+  bgRect.size({ width: outerW, height: outerH }).position({
+    x: (stage.width() - outerW) / 2,
+    y: (stage.height() - outerH) / 2
   });
+
+  // 暗枠（film時のみ表示、白枠の内側）
+  filmRect.visible(isFilm);
+  if (isFilm) {
+    filmRect.size({ width: canvasW, height: canvasH }).position({
+      x: (stage.width() - canvasW) / 2,
+      y: (stage.height() - canvasH) / 2
+    });
+  }
 
   // 画像を中央に配置
   imgNode.size({ width: fit.w, height: fit.h }).position({


### PR DESCRIPTION
参考画像に合わせ、暗いフィルム枠の外側に薄い白枠を追加。
保存時は長辺の0.7%の白枠を追加、プレビューは8px固定の白枠＋
暗枠のKonvaレイヤーで3層を表現する。