### PR TITLE
ポラロイドフレームを追加（上左右均等＋下2.5倍の白枠）

### DIFF
--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ function createFilmFrameRaw(canvasW, canvasH, leftOffset, topOffset, contentW, c
 
 ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPercent, borderType = "white" }) => {
   const name = path.basename(inputPath, path.extname(inputPath));
-  const suffix = borderType === "film" ? "film" : "white";
+  const suffix = borderType === "film" ? "film" : borderType === "polaroid" ? "polaroid" : "white";
   const outPath = path.join(outDir, `${name}_fitted_${aspectRatio.replace(":", "x")}_${borderPercent}pct_${suffix}.jpg`);
 
   const img = sharp(inputPath).rotate();
@@ -164,6 +164,32 @@ ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPer
     // Step2: 確実に全辺に白枠を追加（チェーンすると適用されない場合があるため分離）
     await sharp(withFrame)
       .extend({ top: whitePx, bottom: whitePx, left: whitePx, right: whitePx, background: whiteBg })
+      .jpeg({ quality: 95 }).toFile(outPath);
+
+  } else if (borderType === "polaroid") {
+    // ポラロイド: 上左右=均等白枠、下=2.5倍の白枠
+    const whiteBg = { r: 255, g: 255, b: 255 };
+    const rotBuf  = await sharp(inputPath).rotate().png().toBuffer();
+    const rotMeta = await sharp(rotBuf).metadata();
+    const imgW = rotMeta.width, imgH = rotMeta.height;
+
+    // アスペクト比指定がある場合はまずコンテンツを合わせる
+    let baseBuf, baseW, baseH;
+    if (aspectRatio === "Original") {
+      baseBuf = rotBuf; baseW = imgW; baseH = imgH;
+    } else {
+      const ratio = aspectRatio === "1:1" ? 1 : 4 / 3;
+      if (imgW / imgH > ratio) { baseW = imgW; baseH = Math.round(imgW / ratio); }
+      else { baseH = imgH; baseW = Math.round(imgH * ratio); }
+      baseBuf = await sharp(rotBuf)
+        .resize({ width: baseW, height: baseH, fit: "contain", background: whiteBg })
+        .png().toBuffer();
+    }
+
+    const sidePx   = Math.max(10, Math.round(Math.max(baseW, baseH) * p));
+    const bottomPx = Math.round(sidePx * 2.5);
+    await sharp(baseBuf)
+      .extend({ top: sidePx, left: sidePx, right: sidePx, bottom: bottomPx, background: whiteBg })
       .jpeg({ quality: 95 }).toFile(outPath);
   }
   return { ok: true };

--- a/renderer.js
+++ b/renderer.js
@@ -51,9 +51,13 @@ borderSlider.oninput = () => {
 };
 
 borderTypeBtn.onclick = () => {
-  borderType = borderType === "white" ? "film" : "white";
-  borderTypeBtn.textContent = borderType === "white" ? "枠: 白" : "枠: フィルム";
-  borderTypeBtn.style.background = borderType === "white" ? "#555" : "#2a1a0a";
+  if (borderType === "white") borderType = "film";
+  else if (borderType === "film") borderType = "polaroid";
+  else borderType = "white";
+  const labels = { white: "枠: 白", film: "枠: フィルム", polaroid: "枠: ポラロイド" };
+  const colors = { white: "#555", film: "#2a1a0a", polaroid: "#1a3a1a" };
+  borderTypeBtn.textContent = labels[borderType];
+  borderTypeBtn.style.background = colors[borderType];
   updateUI();
   layer.draw();
 };
@@ -111,6 +115,26 @@ function updateUI() {
   if (!fit.w) return;
 
   const p = borderPercent / 100;
+
+  // ポラロイドモード: 上左右=均等、下=2.5倍の白枠
+  if (borderType === "polaroid") {
+    const sideMarg   = Math.max(fit.w, fit.h) * p;
+    const bottomMarg = sideMarg * 2.5;
+    const canvasW = fit.w + sideMarg * 2;
+    const canvasH = fit.h + sideMarg + bottomMarg;
+    bgRect.fill("white");
+    bgRect.size({ width: canvasW, height: canvasH }).position({
+      x: (stage.width() - canvasW) / 2,
+      y: (stage.height() - canvasH) / 2
+    });
+    filmRect.visible(false);
+    imgNode.size({ width: fit.w, height: fit.h }).position({
+      x: (stage.width() - fit.w) / 2,
+      y: (stage.height() - canvasH) / 2 + sideMarg
+    });
+    return;
+  }
+
   let canvasW, canvasH;
 
   if (aspectRatio === "Original") {


### PR DESCRIPTION
枠の種類を白・フィルム・ポラロイドの3種類にトグル拡張。
ポラロイドは上左右=borderPercent%、下=2.5倍の白枠を生成する。
アスペクト比選択にも対応（Originalはそのまま、4:3/1:1はcontainで合わせてから追加）。 プレビューでも画像が上寄りに配置され下の余白が広く見える。