### PR TITLE
ポラロイド枠の下余白を2.5倍→1.5倍に、基準を短辺に変更

### DIFF
--- a/main.js
+++ b/main.js
@@ -186,8 +186,8 @@ ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPer
         .png().toBuffer();
     }
 
-    const sidePx   = Math.max(10, Math.round(Math.max(baseW, baseH) * p));
-    const bottomPx = Math.round(sidePx * 2.5);
+    const sidePx   = Math.max(10, Math.round(Math.min(baseW, baseH) * p));
+    const bottomPx = Math.round(sidePx * 1.5);
     await sharp(baseBuf)
       .extend({ top: sidePx, left: sidePx, right: sidePx, bottom: bottomPx, background: whiteBg })
       .jpeg({ quality: 95 }).toFile(outPath);

--- a/renderer.js
+++ b/renderer.js
@@ -118,8 +118,8 @@ function updateUI() {
 
   // ポラロイドモード: 上左右=均等、下=2.5倍の白枠
   if (borderType === "polaroid") {
-    const sideMarg   = Math.max(fit.w, fit.h) * p;
-    const bottomMarg = sideMarg * 2.5;
+    const sideMarg   = Math.min(fit.w, fit.h) * p;
+    const bottomMarg = sideMarg * 1.5;
     const canvasW = fit.w + sideMarg * 2;
     const canvasH = fit.h + sideMarg + bottomMarg;
     bgRect.fill("white");


### PR DESCRIPTION
参考画像に合わせ、下余白の比率を縮小して四辺がより均等に見えるよう調整。
マージン基準も長辺から短辺に変更し、縦長画像で余白が大きくなりすぎるのを防ぐ。