### PR TITLE
ポラロイドに細い黒枠を追加して3層構造に（白枠→黒枠→写真）

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,7 +188,13 @@ ipcMain.handle("fit-save", async (_, { inputPath, outDir, aspectRatio, borderPer
 
     const sidePx   = Math.max(10, Math.round(Math.min(baseW, baseH) * p));
     const bottomPx = Math.round(sidePx * 1.5);
-    await sharp(baseBuf)
+    // Step1: 細い黒枠を内側に追加
+    const darkPx = Math.max(4, Math.round(Math.min(baseW, baseH) * 0.004));
+    const withDark = await sharp(baseBuf)
+      .extend({ top: darkPx, left: darkPx, right: darkPx, bottom: darkPx, background: { r: 10, g: 10, b: 10 } })
+      .png().toBuffer();
+    // Step2: 白枠を外側に追加
+    await sharp(withDark)
       .extend({ top: sidePx, left: sidePx, right: sidePx, bottom: bottomPx, background: whiteBg })
       .jpeg({ quality: 95 }).toFile(outPath);
   }

--- a/renderer.js
+++ b/renderer.js
@@ -120,17 +120,28 @@ function updateUI() {
   if (borderType === "polaroid") {
     const sideMarg   = Math.min(fit.w, fit.h) * p;
     const bottomMarg = sideMarg * 1.5;
-    const canvasW = fit.w + sideMarg * 2;
-    const canvasH = fit.h + sideMarg + bottomMarg;
+    const darkPx = 5; // プレビュー用の細い黒枠
+    const innerW = fit.w + darkPx * 2;
+    const innerH = fit.h + darkPx * 2;
+    const outerW = innerW + sideMarg * 2;
+    const outerH = innerH + sideMarg + bottomMarg;
+    // 白枠（外）
     bgRect.fill("white");
-    bgRect.size({ width: canvasW, height: canvasH }).position({
-      x: (stage.width() - canvasW) / 2,
-      y: (stage.height() - canvasH) / 2
+    bgRect.size({ width: outerW, height: outerH }).position({
+      x: (stage.width() - outerW) / 2,
+      y: (stage.height() - outerH) / 2
     });
-    filmRect.visible(false);
+    // 黒枠（内）
+    filmRect.visible(true);
+    filmRect.fill("#0a0a0a");
+    filmRect.size({ width: innerW, height: innerH }).position({
+      x: (stage.width() - innerW) / 2,
+      y: (stage.height() - outerH) / 2 + sideMarg
+    });
+    // 写真
     imgNode.size({ width: fit.w, height: fit.h }).position({
       x: (stage.width() - fit.w) / 2,
-      y: (stage.height() - canvasH) / 2 + sideMarg
+      y: (stage.height() - outerH) / 2 + sideMarg + darkPx
     });
     return;
   }


### PR DESCRIPTION
参考画像に合わせ、白枠の内側に細い黒枠（短辺の0.4%、最小4px）を追加。
プレビューもfilmRectを再利用して白・黒・写真の3層を表示するよう更新。